### PR TITLE
Update hugo build script, move build styles into manager-styles.css, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "storybook": "STORYBOOK_WEBSITE_TARGET=FLUIDFRAMEWORK start-storybook -p 9009 -s public",
     "start": "start-storybook -p 9009 -s public",
     "start:server": "tinylicious",
-    "build": "build-storybook -s public"
+    "build": "build-storybook -s public",
+    "build:hugo": "build-storybook -s public && node hugo-build-script.js"
   },
   "dependencies": {
     "@blueprintjs/core": "^3.31.0",

--- a/public/manager-styles.css
+++ b/public/manager-styles.css
@@ -72,3 +72,9 @@
         width: 1170px;
     }
 }
+
+/* Pulled from Storybook's build version of index.html - needed for Hugo <link> embed */
+#root[hidden],
+#docs-root[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
1. Update hugo build scripts
2. Move Storybook build index.html styles into manager-styles.css
3. Add build:hugo script in package.json

`npm run build:hugo` will extract content from `index.html` and create a `playground.html` file with Hugo template syntax. This is the script that should be run in devops so that the `playground.html` file and others created from the Storybook build are copied over to the Hugo content. 

**Note:** If we end up running into issues with the regex there's a plan B I can think of. No regex but not sure I'm a fan of it either.

## FluidStorybook DevOps Summary

1. Trigger a build by running `npm run build:hugo`

## FluidFramework DevOps Summary

1. Pull .tar from Storybook repo
2. Extract to `docs/static/playground` in Hugo.
3. The `playground.html` file (now in `docs/static/playground`) needs to be copied to `docs/layouts/page/`.
4. Finish the normal Hugo build process

This all (should) work due to a file Matt added. See https://github.com/microsoft/FluidFramework/pull/3377.