### PR TITLE
Fix for dice rolled every time a document was loaded

### DIFF
--- a/src/fluidObjects/diceRollerJS/DiceRollerView.js
+++ b/src/fluidObjects/diceRollerJS/DiceRollerView.js
@@ -31,8 +31,8 @@ export function DiceRollerView(model, contentDiv) {
         contentDiv.appendChild(createButton());
         // Listen for changes to DiceRoller values
         model.on("diceRolled", onDiceRolled);
-        // Trigger initial roll
-        model.roll();
+        // Render initial dice value.
+        onDiceRolled();
     }
 
     const createButton = () => {
@@ -65,7 +65,8 @@ export function DiceRollerView(model, contentDiv) {
 //         model.on("diceRolled", () => this.onDiceRolled());
 //         // To remove listener
 //         // model.off("diceRolled", this.onDiceRolled);
-//         this.model.roll();
+//         // Render initial dice value.
+//         this.onDiceRolled();
 //     }
 
 //     onDiceRolled() {


### PR DESCRIPTION
In the DiceRollerJS data object, the dice was rolled every time it was loaded. However, it should get the value from the model the first time instead of a new roll. When a new client joins, we want them to get the current value of the dice.