### PR TITLE
Update Storybook build script for Hugo template and cache-scripts feature

### DIFF
--- a/hugo-build-script.js
+++ b/hugo-build-script.js
@@ -96,7 +96,6 @@ function cleanupContent(stylesheetLinksContent, content) {
 
         // Replace root path with /playground so that https://site.com/playground and https://site.com/playground/ both work
         stylesheetLinks = stylesheetLinks.replace(/href="/g, 'href="/playground/');
-        // body = body.replace(/src="(\.\/)?]/g, 'src="/playground');
         body = body.replace(/src="(\.\/)?/g, 'src="/playground/');
     }
     else {


### PR DESCRIPTION
Modify build script to create Hugo **playground.html** and new **cache-scripts.js** files:

* Modified script to append **/playground/** at the front of all CSS and script paths so that **/playground** and **/playground/** works correctly on the site (will eliminate 404s if user goes to https://site.com/playground.
* Extract specific Storybook build script names and add them to a new file named **cache-scripts.js** that will be loaded into the main site to do prefetching of the scripts.
* General refactoring since it's getting a bit bigger now.