### PR TITLE
Remove demo title (for now - needs more work)

### DIFF
--- a/src/fluidRendering/fluidLoader.tsx
+++ b/src/fluidRendering/fluidLoader.tsx
@@ -23,7 +23,6 @@ export interface FluidLoaderProps {
 
 export const FluidLoader = (props: React.PropsWithChildren<FluidLoaderProps>) => { 
     const fluidNodeRef = useRef<HTMLDivElement>(null);
-    // const [title, setTitle] = useState("");
 
     useEffect(() => {
         async function render() {


### PR DESCRIPTION
Removing the title that shows above each demo since the MDX/Docs page already has a title. Gets it back to where it was earlier.