### PR TITLE
Add fetch api support for prefetching scripts and adds <base> tag for relative path resolution

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -3,4 +3,5 @@ import fluidTheme from './fluid-theme';
 
 addons.setConfig({
   theme: fluidTheme,
+  showRoots: true
 });

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,11 +13,6 @@ const sortOptions = {
 
 export const parameters = {
   options: {
-    /**
-     * display the top-level grouping as a "root" in the sidebar
-     * @type {Boolean}
-     */
-    showRoots: true,
     showPanel: false,
     storySort: storySort(sortOptions)
   },


### PR DESCRIPTION
* Update Hugo build script. 

Removes src/href replace modifications due to adding script to generate base tag in playground.html which sets the base path to /playground/. Update build script to generate a prefetch script that uses the fetch() api (script tags used as a fallback). When fetch() is used the user won't see a spinner on the tab as they would when adding script tags dynamically. 
* Remove Storybook warning about showRoots (minor change).

Everything has been run locally with latest FluidFramework Hugo version.