### PR TITLE
Fix menu contrast for accessibility

### DIFF
--- a/public/manager-styles.css
+++ b/public/manager-styles.css
@@ -144,7 +144,8 @@ button[title="Clear search"], button[title="Clear search"]:hover {
     }
 
     /* Selected sidebar item contrast ration is not high enough */
-    .sidebar-container .sidebar-item.selected {
+    .sidebar-container .sidebar-item.selected,
+    .sidebar-container .sidebar-item[data-selected="true"] {
         background: #0078d4;
     }
 


### PR DESCRIPTION
There was a regression to #64 when we upgraded Storybook in #68. Storybook's HTML changed so the CSS selectors needed to be updated appropriately.