### PR TITLE
converts pipeline to new M365 template

### DIFF
--- a/.azuredevops/build-ci.yml
+++ b/.azuredevops/build-ci.yml
@@ -25,7 +25,7 @@ extends:
   template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: NewLarge-linux-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
+      name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
       os: linux
     sdl:
       arrow:

--- a/.azuredevops/build-ci.yml
+++ b/.azuredevops/build-ci.yml
@@ -42,9 +42,9 @@ extends:
     customBuildTags:
       - ES365AIMigrationTooling
     stages:
-      - stage: stage
+      - stage: Run_build
         jobs:
-          - job: job
+          - job: Run_build
             steps:
               - task: ComponentGovernanceComponentDetection@0
                 inputs:

--- a/.azuredevops/build-ci.yml
+++ b/.azuredevops/build-ci.yml
@@ -12,49 +12,74 @@ pr:
 variables:
   skipComponentGovernanceDetection: true
 
-pool: 'Lite'
+resources:
+  repositories:
+    - repository: m365Pipelines
+      type: git
+      name: 1ESPipelineTemplates/M365GPT
+      ref: refs/tags/release
+extends:
+  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  parameters:
+    pool:
+      name: NewLarge-linux-1ES
+      os: linux
+    sdl:
+      arrow:
+        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
+        # Currently we want to use different names for internal and public builds for Arrow Service Connection
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          serviceConnection: Arrow_FluidFramework_internal
+        ${{ else }}:
+          serviceConnection: Arrow_FluidFramework_public
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-2022
+        os: windows
+    customBuildTags:
+      - ES365AIMigrationTooling
+    stages:
+      - stage: stage
+        jobs:
+          - job: job
+            steps:
+              - task: ComponentGovernanceComponentDetection@0
+                inputs:
+                  scanType: 'Register'
+                  verbosity: 'Verbose'
+                  alertWarningLevel: 'High'
+              - task: UseNode@1
+                displayName: Use Node 12.x
+                inputs:
+                  version: 12.x
+              - task: Npm@1
+                displayName: Install
+                inputs:
+                  command: 'custom'
+                  customCommand: 'install'
 
-steps:
-- task: ComponentGovernanceComponentDetection@0
-  inputs:
-    scanType: 'Register'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
-- task: UseNode@1
-  displayName: Use Node 12.x
-  inputs: 
-    version: 12.x
+              # Remove Policy Check until folder issue is resolved
+              # - task: Npm@1
+              #   displayName: Policy Check
+              #   inputs:
+              #     command: 'custom'
+              #     customCommand: 'run policy-check'
 
-- task: Npm@1
-  displayName: Install
-  inputs:
-    command: 'custom'
-    customCommand: 'install'
-
-# Remove Policy Check until folder issue is resolved
-# - task: Npm@1
-#   displayName: Policy Check
-#   inputs:
-#     command: 'custom'
-#     customCommand: 'run policy-check'
-
-- task: Npm@1
-  displayName: Build
-  inputs:
-    command: 'custom'
-    customCommand: 'run build'
-
-- task: Npm@1
-  displayName: Test
-  inputs:
-    command: 'custom'
-    customCommand: 'run test -- --reporters=default --reporters=jest-junit'
-
-- task: PublishTestResults@2
-  displayName: Publish Test Results
-  inputs:
-    testResultsFormat: 'JUnit'
-    testResultsFiles: '**/*junit-report.xml'
-    searchFolder: nyc
-    mergeTestResults: true
-  condition: succeededOrFailed()
+              - task: Npm@1
+                displayName: Build
+                inputs:
+                  command: 'custom'
+                  customCommand: 'run build'
+              - task: Npm@1
+                displayName: Test
+                inputs:
+                  command: 'custom'
+                  customCommand: 'run test -- --reporters=default --reporters=jest-junit'
+              - task: PublishTestResults@2
+                displayName: Publish Test Results
+                inputs:
+                  testResultsFormat: 'JUnit'
+                  testResultsFiles: '**/*junit-report.xml'
+                  searchFolder: nyc
+                  mergeTestResults: true
+                condition: succeededOrFailed()

--- a/.azuredevops/build-ci.yml
+++ b/.azuredevops/build-ci.yml
@@ -12,6 +12,7 @@ pr:
 variables:
   skipComponentGovernanceDetection: true
 
+# The `resources` specify the location and version of the 1ES PT.
 resources:
   repositories:
     - repository: m365Pipelines
@@ -19,10 +20,12 @@ resources:
       name: 1ESPipelineTemplates/M365GPT
       ref: refs/tags/release
 extends:
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
   template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: NewLarge-linux-1ES
+      name: NewLarge-linux-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
       os: linux
     sdl:
       arrow:


### PR DESCRIPTION
This PR converts the FluidStoryBook pipeline to the new 1ES template required by Microsoft. The pipeline essentially now extends a new template from Microsoft that enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview) 